### PR TITLE
src/bin: Make sure to authenticate before multiplexing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4.8"
 env_logger = "0.7.0"
 futures = "0.1.29"
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", branch = "master" }
+libp2p-secio = { git = "https://github.com/libp2p/rust-libp2p.git", branch = "master", path = "protocols/secio" }
 tokio = "0.1.22"
 
 [[bin]]

--- a/src/bin/network_tester.rs
+++ b/src/bin/network_tester.rs
@@ -7,6 +7,7 @@ use libp2p::mplex::MplexConfig;
 use libp2p::core::upgrade::SelectUpgrade;
 use libp2p::core::transport::upgrade::{Builder, Version};
 use libp2p::yamux;
+use libp2p_secio as secio;
 
 fn main() {
     env_logger::init();
@@ -17,7 +18,7 @@ fn main() {
     println!("Local peer id: {:?}", peer_id);
 
     let transport = TcpConfig::new();
-    let builder = transport.upgrade(Version::V1);
+    let builder = transport.upgrade(Version::V1)
+        .authenticate(secio::SecioConfig::new(id_keys));
     let res = builder.multiplex(MplexConfig::new());
-
 }


### PR DESCRIPTION
`multiplex` requires the passed transport to be authenticated:

```rust
/// Upgrades the transport with a (sub)stream multiplexer.
///
/// The supplied upgrade receives the I/O resource `C` and must
/// produce a [`StreamMuxer`] `M`. The transport must already be authenticated.
/// This ends the (regular) transport upgrade process, yielding the underlying,
/// configured transport.
///
/// ## Transitions
///
///   * I/O upgrade: `C -> M`.
///   * Transport output: `(I, C) -> (I, M)`.
pub fn multiplex<C, M, U, I, E>(self, upgrade: U)
```