### PR TITLE
src/bin: Use plaintext 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4.8"
 env_logger = "0.7.0"
 futures = "0.1.29"
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", branch = "master" }
-libp2p-secio = { git = "https://github.com/libp2p/rust-libp2p.git", branch = "master", path = "protocols/secio" }
+libp2p-plaintext = { git = "https://github.com/libp2p/rust-libp2p.git", branch = "master", path = "protocols/plaintext" }
 tokio = "0.1.22"
 
 [[bin]]

--- a/src/bin/network_tester.rs
+++ b/src/bin/network_tester.rs
@@ -7,7 +7,7 @@ use libp2p::mplex::MplexConfig;
 use libp2p::core::upgrade::SelectUpgrade;
 use libp2p::core::transport::upgrade::{Builder, Version};
 use libp2p::yamux;
-use libp2p_secio as secio;
+use libp2p_plaintext;
 
 fn main() {
     env_logger::init();
@@ -19,6 +19,6 @@ fn main() {
 
     let transport = TcpConfig::new();
     let builder = transport.upgrade(Version::V1)
-        .authenticate(secio::SecioConfig::new(id_keys));
+        .authenticate(libp2p_plaintext::PlainText2Config{local_public_key: id_keys.public()});
     let res = builder.multiplex(MplexConfig::new());
 }


### PR DESCRIPTION
You might want to use plaintext instead of secio in order to be able to sniff on the network traffic e.g. with wireshark.